### PR TITLE
Add Windows build support with MinGW cross-compilation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,21 +49,23 @@ jobs:
       run: |
         wget https://github.com/libsdl-org/SDL/releases/download/release-2.30.10/SDL2-devel-2.30.10-mingw.tar.gz
         tar -xzf SDL2-devel-2.30.10-mingw.tar.gz
-        sudo cp -r SDL2-2.30.10/x86_64-w64-mingw32/include/SDL2 /usr/x86_64-w64-mingw32/include/
-        sudo cp -r SDL2-2.30.10/x86_64-w64-mingw32/lib/* /usr/x86_64-w64-mingw32/lib/
-        sudo cp -r SDL2-2.30.10/x86_64-w64-mingw32/bin/*.dll /usr/x86_64-w64-mingw32/bin/
+        export SDL2_DIR=$(pwd)/SDL2-2.30.10/x86_64-w64-mingw32
+        echo "SDL2_DIR=$SDL2_DIR" >> $GITHUB_ENV
 
     - name: Build Windows
       run: |
         mkdir build-windows && cd build-windows
-        cmake -DCMAKE_TOOLCHAIN_FILE=../cmake/mingw-w64-x86_64.cmake ..
+        cmake -DCMAKE_TOOLCHAIN_FILE=../cmake/mingw-w64-x86_64.cmake \
+              -DSDL2_INCLUDE_DIR=$SDL2_DIR/include/SDL2 \
+              -DSDL2_LIBRARY=$SDL2_DIR/lib/libSDL2.dll.a \
+              ..
         make -j$(nproc)
 
     - name: Package Windows Build
       run: |
         mkdir -p BreakOut-Windows
         cp build-windows/BreakOut.exe BreakOut-Windows/
-        cp /usr/x86_64-w64-mingw32/bin/SDL2.dll BreakOut-Windows/
+        cp $SDL2_DIR/bin/SDL2.dll BreakOut-Windows/
 
     - name: Upload Windows Build
       uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
         mkdir build-windows && cd build-windows
         cmake -DCMAKE_TOOLCHAIN_FILE=../cmake/mingw-w64-x86_64.cmake \
               -DSDL2_INCLUDE_DIR=$SDL2_DIR/include/SDL2 \
-              -DSDL2_LIBRARY=$SDL2_DIR/lib/libSDL2.dll.a \
+              -DSDL2_LIBRARY="$SDL2_DIR/lib/libSDL2main.a;$SDL2_DIR/lib/libSDL2.dll.a" \
               ..
         make -j$(nproc)
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,42 @@ jobs:
         name: BreakOut-Linux
         path: build/BreakOut
 
+  build-windows:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install MinGW and SDL2
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y mingw-w64 cmake wget unzip
+
+    - name: Download SDL2 for MinGW
+      run: |
+        wget https://github.com/libsdl-org/SDL/releases/download/release-2.30.10/SDL2-devel-2.30.10-mingw.tar.gz
+        tar -xzf SDL2-devel-2.30.10-mingw.tar.gz
+        sudo cp -r SDL2-2.30.10/x86_64-w64-mingw32/include/SDL2 /usr/x86_64-w64-mingw32/include/
+        sudo cp -r SDL2-2.30.10/x86_64-w64-mingw32/lib/* /usr/x86_64-w64-mingw32/lib/
+        sudo cp -r SDL2-2.30.10/x86_64-w64-mingw32/bin/*.dll /usr/x86_64-w64-mingw32/bin/
+
+    - name: Build Windows
+      run: |
+        mkdir build-windows && cd build-windows
+        cmake -DCMAKE_TOOLCHAIN_FILE=../cmake/mingw-w64-x86_64.cmake ..
+        make -j$(nproc)
+
+    - name: Package Windows Build
+      run: |
+        mkdir -p BreakOut-Windows
+        cp build-windows/BreakOut.exe BreakOut-Windows/
+        cp /usr/x86_64-w64-mingw32/bin/SDL2.dll BreakOut-Windows/
+
+    - name: Upload Windows Build
+      uses: actions/upload-artifact@v4
+      with:
+        name: BreakOut-Windows
+        path: BreakOut-Windows/
+
   build-wasm:
     runs-on: ubuntu-latest
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Build outputs
 build/
+build-windows/
 build-portmaster-*/
 portmaster-package/
 *.o
@@ -10,6 +11,8 @@ portmaster-package/
 *.velf
 *.elf
 *.zip
+*.exe
+*.dll
 
 # Emscripten outputs
 *.wasm

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,8 +24,15 @@ endif()
 
 # Find SDL2
 if(NOT VITA AND NOT EMSCRIPTEN)
-    find_package(SDL2 REQUIRED)
-    include_directories(${SDL2_INCLUDE_DIRS})
+    # Allow manual SDL2 paths for Windows cross-compilation
+    if(WIN32 AND DEFINED SDL2_INCLUDE_DIR AND DEFINED SDL2_LIBRARY)
+        message(STATUS "Using manually specified SDL2 paths")
+        include_directories(${SDL2_INCLUDE_DIR})
+        set(SDL2_LIBRARIES ${SDL2_LIBRARY})
+    else()
+        find_package(SDL2 REQUIRED)
+        include_directories(${SDL2_INCLUDE_DIRS})
+    endif()
 endif()
 
 # Source files (add more as we implement them)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,8 +128,7 @@ elseif(WIN32)
     # Windows (MinGW)
     target_link_libraries(BreakOut
         mingw32
-        SDL2main
-        SDL2
+        ${SDL2_LIBRARIES}
         m
     )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,8 @@ elseif(PORTMASTER)
     message(STATUS "Building for PortMaster (ARM Linux)")
     set(PORT_NAME "breakout")
     set(PORT_VERSION "1.0.0")
+elseif(WIN32)
+    message(STATUS "Building for Windows")
 else()
     message(STATUS "Building for Linux/Desktop")
 endif()
@@ -113,6 +115,20 @@ elseif(EMSCRIPTEN)
     target_link_options(BreakOut PRIVATE
         -sUSE_SDL=2
         -sALLOW_MEMORY_GROWTH=1
+    )
+
+elseif(WIN32)
+    # Windows (MinGW)
+    target_link_libraries(BreakOut
+        mingw32
+        SDL2main
+        SDL2
+        m
+    )
+
+    # Set Windows subsystem to avoid console window
+    set_target_properties(BreakOut PROPERTIES
+        WIN32_EXECUTABLE TRUE
     )
 
 else()

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # BreakOut - Cross-Platform Breakout Game
 
-A classic Breakout game built in C with SDL2, targeting PS Vita, Linux, WebAssembly, and PortMaster (Anbernic/handheld devices).
+A classic Breakout game built in C with SDL2, targeting PS Vita, Linux, Windows, WebAssembly, and PortMaster (Anbernic/handheld devices).
 
 ## Features
 
 - **4 Development Stages**: Basic blockout → Simple graphics → Game flow & scoring → Polish & effects
-- **Cross-Platform**: PS Vita (primary), Linux (development), WebAssembly (web demo), PortMaster (Anbernic/handhelds)
+- **Cross-Platform**: PS Vita (primary), Linux (development), Windows (PC), WebAssembly (web demo), PortMaster (Anbernic/handhelds)
 - **Fixed Resolution**: 960×544 (PS Vita native) with letterboxing on other resolutions
 - **Performance**: 60 FPS target on Vita, smooth gameplay on all platforms
 
@@ -27,6 +27,10 @@ sudo apt-get install libsdl2-dev libsdl2-mixer-dev libsdl2-image-dev cmake build
 - Install [Emscripten SDK](https://emscripten.org/docs/getting_started/downloads.html)
 - Run `source /path/to/emsdk/emsdk_env.sh`
 
+**Windows**:
+- Install [MinGW-w64](https://www.mingw-w64.org/)
+- Download [SDL2 for MinGW](https://github.com/libsdl-org/SDL/releases)
+
 **PortMaster (Anbernic/Handhelds)**:
 - Install [Docker](https://docs.docker.com/get-docker/)
 - Ensure Docker daemon is running: `sudo systemctl start docker`
@@ -39,6 +43,15 @@ mkdir build && cd build
 cmake ..
 make
 ./BreakOut
+```
+
+**Windows (Cross-compile from Linux)**:
+```bash
+mkdir build-windows && cd build-windows
+cmake -DCMAKE_TOOLCHAIN_FILE=../cmake/mingw-w64-x86_64.cmake ..
+make
+
+# Output: BreakOut.exe (requires SDL2.dll)
 ```
 
 **PS Vita**:

--- a/cmake/mingw-w64-x86_64.cmake
+++ b/cmake/mingw-w64-x86_64.cmake
@@ -1,0 +1,20 @@
+# MinGW-w64 toolchain file for cross-compiling to Windows from Linux
+
+set(CMAKE_SYSTEM_NAME Windows)
+set(CMAKE_SYSTEM_PROCESSOR x86_64)
+
+# Specify the cross compiler
+set(CMAKE_C_COMPILER x86_64-w64-mingw32-gcc)
+set(CMAKE_CXX_COMPILER x86_64-w64-mingw32-g++)
+set(CMAKE_RC_COMPILER x86_64-w64-mingw32-windres)
+
+# Where to find the target environment
+set(CMAKE_FIND_ROOT_PATH /usr/x86_64-w64-mingw32)
+
+# Adjust the default behavior of the FIND_XXX() commands:
+# search programs in the host environment
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+
+# search headers and libraries in the target environment
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)

--- a/src/game/ball.h
+++ b/src/game/ball.h
@@ -1,7 +1,7 @@
 #ifndef BALL_H
 #define BALL_H
 
-#ifdef __EMSCRIPTEN__
+#if defined(__EMSCRIPTEN__) || defined(_WIN32)
 #include <SDL.h>
 #else
 #include <SDL2/SDL.h>

--- a/src/game/brick.h
+++ b/src/game/brick.h
@@ -1,7 +1,7 @@
 #ifndef BRICK_H
 #define BRICK_H
 
-#ifdef __EMSCRIPTEN__
+#if defined(__EMSCRIPTEN__) || defined(_WIN32)
 #include <SDL.h>
 #else
 #include <SDL2/SDL.h>

--- a/src/game/paddle.h
+++ b/src/game/paddle.h
@@ -1,7 +1,7 @@
 #ifndef PADDLE_H
 #define PADDLE_H
 
-#ifdef __EMSCRIPTEN__
+#if defined(__EMSCRIPTEN__) || defined(_WIN32)
 #include <SDL.h>
 #else
 #include <SDL2/SDL.h>

--- a/src/main.c
+++ b/src/main.c
@@ -1,6 +1,8 @@
-#ifdef __EMSCRIPTEN__
+#if defined(__EMSCRIPTEN__) || defined(_WIN32)
 #include <SDL.h>
+#ifdef __EMSCRIPTEN__
 #include <emscripten.h>
+#endif
 #else
 #include <SDL2/SDL.h>
 #endif


### PR DESCRIPTION
Windows Build System:
- CMakeLists.txt: Windows platform detection and linking
- cmake/mingw-w64-x86_64.cmake: MinGW toolchain file
- Links against mingw32, SDL2main, SDL2
- WIN32_EXECUTABLE set to avoid console window

GitHub Actions CI:
- build-windows job added
- Downloads SDL2 for MinGW automatically
- Cross-compiles from Ubuntu runner
- Packages .exe with SDL2.dll
- Uploads as BreakOut-Windows artifact

Documentation:
- Updated README.md with Windows build instructions
- Added MinGW prerequisites
- Cross-compile instructions from Linux
- Updated .gitignore for .exe and .dll files

Build Targets Now: 5 platforms
1. Linux (x86_64)
2. Windows (x86_64 via MinGW)
3. PS Vita VPK
4. WebAssembly
5. PortMaster ARM64

🤖 Generated with [Claude Code](https://claude.com/claude-code)